### PR TITLE
Set project version to RELEASE

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.coco"
-version = "0.0.1-SNAPSHOT"
+version = "0.0.1-RELEASE"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
**Description:**
- Updated project version from SNAPSHOT to RELEASE in build.gradle.kts.
- Indicates project is ready for a stable release.