### PR TITLE
Add DurationToLongJpaConverter  

### DIFF
--- a/infra/infra-jpa/src/main/kotlin/org/coco/infra/jpa/EnableJpaConfig.kt
+++ b/infra/infra-jpa/src/main/kotlin/org/coco/infra/jpa/EnableJpaConfig.kt
@@ -1,6 +1,7 @@
 package org.coco.infra.jpa
 
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.autoconfigure.KotlinJdslAutoConfiguration
+import org.coco.infra.jpa.converter.DurationToLongJpaConverter
 import org.coco.infra.jpa.core.BallAuditRevisionListener
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.context.annotation.Import
@@ -19,6 +20,7 @@ import kotlin.reflect.KClass
 @Import(
     BallAuditRevisionListener::class,
     KotlinJdslAutoConfiguration::class,
+    DurationToLongJpaConverter::class,
 )
 annotation class EnableJpaConfig(
     @get:AliasFor(

--- a/infra/infra-jpa/src/main/kotlin/org/coco/infra/jpa/converter/DurationToLongJpaConverter.kt
+++ b/infra/infra-jpa/src/main/kotlin/org/coco/infra/jpa/converter/DurationToLongJpaConverter.kt
@@ -1,0 +1,13 @@
+package org.coco.infra.jpa.converter
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
+@Converter(autoApply = true)
+class DurationToLongJpaConverter : AttributeConverter<Duration, Long> {
+    override fun convertToDatabaseColumn(attribute: Duration?): Long = attribute?.toNanos() ?: 0L
+
+    override fun convertToEntityAttribute(dbData: Long): Duration = Duration.of(dbData, ChronoUnit.NANOS)
+}


### PR DESCRIPTION
### Description
- Added `DurationToLongJpaConverter` for converting `Duration` to `Long` for database storage and vice versa.
- Updated `EnableJpaConfig` to include the converter for automatic application across JPA entities.