### PR TITLE
Add `HidingToResponse` annotation for sensitive field handling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.github.project-coco"
-version = "1.0.14-RELEASE"
+version = "1.0.15-RELEASE"
 
 repositories {
     mavenCentral()

--- a/core-utils/src/main/kotlin/org/coco/core/utils/HidingToResponse.kt
+++ b/core-utils/src/main/kotlin/org/coco/core/utils/HidingToResponse.kt
@@ -1,0 +1,5 @@
+package org.coco.core.utils
+
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class HidingToResponse

--- a/domain/src/main/kotlin/org/coco/domain/model/user/BasicUser.kt
+++ b/domain/src/main/kotlin/org/coco/domain/model/user/BasicUser.kt
@@ -1,6 +1,7 @@
 package org.coco.domain.model.user
 
 import org.coco.core.type.BinaryId
+import org.coco.core.utils.HidingToResponse
 import org.coco.core.utils.ToStringBuilder
 import org.coco.core.utils.currentClock
 import org.coco.domain.model.EntityBase
@@ -25,6 +26,7 @@ open class BasicUser(
     var username: Username = username
         protected set
 
+    @HidingToResponse
     var rolesAsString: Set<String> = roles
         protected set
 
@@ -34,6 +36,7 @@ open class BasicUser(
     var phoneNumber: PhoneNumber = phoneNumber
         protected set
 
+    @HidingToResponse
     var passwordHash: PasswordHash = passwordHash
         protected set
 

--- a/presentation/presentation-mvc/src/main/kotlin/org/coco/presentation/mvc/middleware/EntityJsonSerializer.kt
+++ b/presentation/presentation-mvc/src/main/kotlin/org/coco/presentation/mvc/middleware/EntityJsonSerializer.kt
@@ -1,0 +1,41 @@
+package org.coco.presentation.mvc.middleware
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import org.coco.core.utils.HidingToResponse
+import org.coco.domain.model.EntityBase
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.jvm.isAccessible
+
+abstract class EntityJsonSerializer : JsonSerializer<EntityBase>() {
+    override fun serialize(
+        value: EntityBase,
+        gen: JsonGenerator,
+        serializers: SerializerProvider,
+    ) {
+        gen.writeStartObject()
+
+        val visibleFields =
+            getVisibleFields(value)
+                .filter { it.findAnnotation<HidingToResponse>() == null }
+
+        writeVisibleFields(gen, value, visibleFields)
+
+        gen.writeEndObject()
+    }
+
+    private fun writeVisibleFields(
+        gen: JsonGenerator,
+        entity: EntityBase,
+        visibleFields: List<KProperty1<Any, *>>,
+    ) {
+        visibleFields.forEach { field ->
+            field.isAccessible = true
+            gen.writeObjectField(field.name, field.get(entity))
+        }
+    }
+
+    protected abstract fun getVisibleFields(entity: EntityBase): List<KProperty1<Any, *>>
+}


### PR DESCRIPTION
### Description

- Introduced a `HidingToResponse` annotation to mark sensitive fields for exclusion in responses.
- Implemented `EntityJsonSerializer` for custom serialization logic that omits fields annotated with `HidingToResponse`.
- Updated `BasicUser` to apply the `HidingToResponse` annotation to sensitive fields such as roles and passwords.