### PR TITLE
Add custom BinaryId serializer and refactor EntityJsonSerializer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.github.project-coco"
-version = "1.0.15-RELEASE"
+version = "1.0.16-RELEASE"
 
 repositories {
     mavenCentral()

--- a/presentation/presentation-mvc/src/main/kotlin/org/coco/presentation/mvc/middleware/BinaryIdSerializerConfig.kt
+++ b/presentation/presentation-mvc/src/main/kotlin/org/coco/presentation/mvc/middleware/BinaryIdSerializerConfig.kt
@@ -1,0 +1,18 @@
+package org.coco.presentation.mvc.middleware
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import org.coco.core.type.BinaryId
+import org.springframework.boot.jackson.JsonComponent
+
+@JsonComponent
+class BinaryIdSerializerConfig : JsonSerializer<BinaryId>() {
+    override fun serialize(
+        value: BinaryId?,
+        gen: JsonGenerator,
+        serializers: SerializerProvider,
+    ) {
+        gen.writeString(value.toString())
+    }
+}

--- a/presentation/presentation-mvc/src/main/kotlin/org/coco/presentation/mvc/middleware/EntityJsonSerializer.kt
+++ b/presentation/presentation-mvc/src/main/kotlin/org/coco/presentation/mvc/middleware/EntityJsonSerializer.kt
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.databind.SerializerProvider
 import org.coco.core.utils.HidingToResponse
 import org.coco.domain.model.EntityBase
 import kotlin.reflect.KProperty1
-import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.jvm.isAccessible
+import kotlin.reflect.jvm.javaField
 
 abstract class EntityJsonSerializer : JsonSerializer<EntityBase>() {
     override fun serialize(
@@ -19,7 +19,9 @@ abstract class EntityJsonSerializer : JsonSerializer<EntityBase>() {
 
         val visibleFields =
             getVisibleFields(value)
-                .filter { it.findAnnotation<HidingToResponse>() == null }
+                .filter {
+                    it.javaField?.getAnnotation(HidingToResponse::class.java) == null
+                }
 
         writeVisibleFields(gen, value, visibleFields)
 


### PR DESCRIPTION
### Description

- Introduced `BinaryIdSerializerConfig` to handle proper JSON conversion for `BinaryId`.
- Updated `EntityJsonSerializer` to leverage `javaField` for annotation lookup, improving the reliability of annotation handling.