### PR TITLE
Add legalName and email fields to user models

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.github.project-coco"
-version = "1.0.16-RELEASE"
+version = "1.0.17-RELEASE"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.github.project-coco"
-version = "1.0.17-RELEASE"
+version = "1.0.18-RELEASE"
 
 repositories {
     mavenCentral()

--- a/domain/src/main/kotlin/org/coco/domain/model/auth/UserPrincipal.kt
+++ b/domain/src/main/kotlin/org/coco/domain/model/auth/UserPrincipal.kt
@@ -2,12 +2,14 @@ package org.coco.domain.model.auth
 
 import org.coco.core.type.BinaryId
 import org.coco.domain.model.user.BasicUser
+import org.coco.domain.model.user.vo.LegalName
 import org.coco.domain.model.user.vo.Username
 import java.security.Principal
 
 data class UserPrincipal(
     val id: BinaryId,
     val username: Username,
+    val legalName: LegalName,
     val roles: Set<String>,
 ) : Principal {
     override fun getName(): String = id.toString()
@@ -17,6 +19,7 @@ data class UserPrincipal(
             UserPrincipal(
                 id = user.id,
                 username = user.username,
+                legalName = user.legalName,
                 roles = user.rolesAsString,
             )
     }

--- a/domain/src/main/kotlin/org/coco/domain/model/user/BasicUser.kt
+++ b/domain/src/main/kotlin/org/coco/domain/model/user/BasicUser.kt
@@ -11,6 +11,7 @@ import java.time.LocalDateTime
 open class BasicUser(
     id: BinaryId = BinaryId.new(),
     username: Username,
+    email: Email? = null,
     roles: Set<String>,
     legalName: LegalName,
     phoneNumber: PhoneNumber,
@@ -24,6 +25,9 @@ open class BasicUser(
     updatedAt: LocalDateTime = LocalDateTime.now(currentClock()),
 ) : EntityBase(id, createdAt, updatedAt) {
     var username: Username = username
+        protected set
+
+    var email: Email? = email
         protected set
 
     @HidingToResponse

--- a/domain/src/main/kotlin/org/coco/domain/model/user/vo/Email.kt
+++ b/domain/src/main/kotlin/org/coco/domain/model/user/vo/Email.kt
@@ -1,0 +1,12 @@
+package org.coco.domain.model.user.vo
+
+@JvmInline
+value class Email(
+    val value: String,
+) {
+    init {
+        require(value.matches(Regex("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$"))) {
+            "잘못된 이메일 형식입니다: $value"
+        }
+    }
+}

--- a/infra/infra-auth-spring-security/src/test/kotlin/org/coco/infra/spring/security/JwtTokenProviderTest.kt
+++ b/infra/infra-auth-spring-security/src/test/kotlin/org/coco/infra/spring/security/JwtTokenProviderTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import org.coco.core.type.BinaryId
 import org.coco.core.utils.JsonUtils
 import org.coco.domain.model.auth.UserPrincipal
+import org.coco.domain.model.user.vo.LegalName
 import org.coco.domain.model.user.vo.Username
 import org.coco.infra.spring.security.TokenProviderJwtHelper.Companion.CLAIM_ID
 import org.coco.infra.spring.security.TokenProviderJwtHelper.Companion.key
@@ -24,6 +25,7 @@ class JwtTokenProviderTest :
                             it.toString()
                         }.toSet(),
                 username = Username(this.key("username")),
+                legalName = LegalName(this.key("legalName")),
             )
         }
         val tokenProvider =
@@ -43,6 +45,7 @@ class JwtTokenProviderTest :
                         id = id,
                         roles = setOf("ROLE_USER"),
                         username = username,
+                        legalName = LegalName("legalName"),
                     ),
                 )
             val jwtString = authToken.value

--- a/infra/infra-jpa/src/main/kotlin/org/coco/infra/jpa/model/user/BasicUserDataModel.kt
+++ b/infra/infra-jpa/src/main/kotlin/org/coco/infra/jpa/model/user/BasicUserDataModel.kt
@@ -16,6 +16,7 @@ import java.time.LocalDateTime
 abstract class BasicUserDataModel<T : BasicUser>(
     id: BinaryId,
     username: Username,
+    email: Email?,
     rolesAsString: Set<String>,
     legalName: LegalName,
     phoneNumber: PhoneNumber,
@@ -30,6 +31,10 @@ abstract class BasicUserDataModel<T : BasicUser>(
 ) : DataModel<T>(id.value, createdAt, updatedAt) {
     @Column(columnDefinition = "varchar(32)", unique = true)
     var username: String = username.value
+        protected set
+
+    @Column(columnDefinition = "varchar(128)", unique = true, nullable = true)
+    var email: String? = email?.value
         protected set
 
     @Type(JsonType::class)
@@ -76,6 +81,7 @@ abstract class BasicUserDataModel<T : BasicUser>(
 
     protected fun update(entity: BasicUser) {
         this.username = entity.username.value
+        this.email = entity.email?.value
         this.rolesAsString = entity.rolesAsString
         this.legalName = entity.legalName.value
         this.phoneNumber = entity.phoneNumber.value

--- a/presentation/presentation-mvc/src/main/kotlin/org/coco/presentation/mvc/core/EnableBallWebMvc.kt
+++ b/presentation/presentation-mvc/src/main/kotlin/org/coco/presentation/mvc/core/EnableBallWebMvc.kt
@@ -5,6 +5,7 @@ import org.coco.application.transaction.TxAdvice
 import org.coco.presentation.mvc.config.SecurityConfig
 import org.coco.presentation.mvc.handler.AuthController
 import org.coco.presentation.mvc.middleware.BallRequestFilter
+import org.coco.presentation.mvc.middleware.BinaryIdSerializerConfig
 import org.coco.presentation.mvc.middleware.ErrorHandler
 import org.coco.presentation.mvc.middleware.RequestLogger
 import org.springframework.context.annotation.Import
@@ -17,5 +18,6 @@ import org.springframework.context.annotation.Import
     SecurityConfig::class,
     AuthController::class,
     TxAdvice::class,
+    BinaryIdSerializerConfig::class,
 )
 annotation class EnableBallWebMvc

--- a/sample-project/src/main/kotlin/org/coco/example/application/UserService.kt
+++ b/sample-project/src/main/kotlin/org/coco/example/application/UserService.kt
@@ -32,6 +32,7 @@ class UserService(
         val user =
             User(
                 username = username,
+                email = null,
                 roles = setOf(User.Role.ROLE_USER),
                 legalName = LegalName(username.value),
                 phoneNumber = PhoneNumber("010-0000-0000"),

--- a/sample-project/src/main/kotlin/org/coco/example/domain/model/user/User.kt
+++ b/sample-project/src/main/kotlin/org/coco/example/domain/model/user/User.kt
@@ -9,6 +9,7 @@ import java.time.LocalDateTime
 class User(
     id: BinaryId = BinaryId.new(),
     username: Username,
+    email: Email?,
     roles: Set<Role>,
     legalName: LegalName,
     phoneNumber: PhoneNumber,
@@ -23,6 +24,7 @@ class User(
 ) : BasicUser(
         id,
         username,
+        email,
         roles.map { it.name }.toSet(),
         legalName,
         phoneNumber,

--- a/sample-project/src/main/kotlin/org/coco/example/infra/jpa/UserRepositoryImpl.kt
+++ b/sample-project/src/main/kotlin/org/coco/example/infra/jpa/UserRepositoryImpl.kt
@@ -43,6 +43,7 @@ class UserRepositoryImpl(
         User(
             id = BinaryId(id),
             username = Username(username),
+            email = null,
             roles = rolesAsString.map { User.Role.valueOf(it) }.toSet(),
             legalName = LegalName(legalName),
             phoneNumber = PhoneNumber(phoneNumber),

--- a/sample-project/src/main/kotlin/org/coco/example/infra/jpa/model/user/UserDataModel.kt
+++ b/sample-project/src/main/kotlin/org/coco/example/infra/jpa/model/user/UserDataModel.kt
@@ -29,6 +29,7 @@ class UserDataModel(
 ) : BasicUserDataModel<User>(
         id,
         username,
+        null,
         rolesAsString,
         legalName,
         phoneNumber,

--- a/sample-project/src/main/kotlin/org/coco/example/presentation/PrincipalConfig.kt
+++ b/sample-project/src/main/kotlin/org/coco/example/presentation/PrincipalConfig.kt
@@ -3,6 +3,7 @@ package org.coco.example.presentation
 import org.coco.core.type.BinaryId
 import org.coco.core.utils.JsonUtils
 import org.coco.domain.model.auth.UserPrincipal
+import org.coco.domain.model.user.vo.LegalName
 import org.coco.domain.model.user.vo.Username
 import org.coco.example.domain.model.user.User
 import org.coco.infra.spring.security.TokenProviderJwtHelper.Companion.CLAIM_ID
@@ -25,6 +26,7 @@ class PrincipalConfig {
                             User.Role.valueOf(it as String).name
                         }.toSet(),
                 username = Username(this.key("username")),
+                legalName = LegalName(this.key("legalName")),
             )
         }
 }


### PR DESCRIPTION
### Description

This pull request enhances user models by:

1. Adding a `legalName` field to `UserPrincipal`, improving user data completeness and aligning with domain requirements. Related tests have been updated to include this new field.
2. Introducing an optional `email` field to `BasicUser` and `BasicUserDataModel` with email format validation. This includes database schema updates, ensuring uniqueness and better management of user data.

