### PR TITLE
Remove redundant check in UserPrincipalContextHolder

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.github.project-coco"
-version = "1.0.19-RELEASE"
+version = "1.0.20-RELEASE"
 
 repositories {
     mavenCentral()

--- a/domain/src/main/kotlin/org/coco/domain/model/auth/UserPrincipalContextHolder.kt
+++ b/domain/src/main/kotlin/org/coco/domain/model/auth/UserPrincipalContextHolder.kt
@@ -8,9 +8,6 @@ object UserPrincipalContextHolder {
         private set(value) = context.set(value)
 
     fun set(userPrincipal: UserPrincipal) {
-        if (this.userPrincipal != null) {
-            throw IllegalStateException("Already authenticated")
-        }
         context.set(userPrincipal)
     }
 


### PR DESCRIPTION
### Description

This pull request removes a duplicate validation in the `set` method of `UserPrincipalContextHolder` to simplify the logic. Additionally, the project version has been updated to `1.0.20-RELEASE` in the build configuration.

### Changes
- Removed redundant check for existing authentication in `UserPrincipalContextHolder`.
- Updated project version to `1.0.20-RELEASE`.
