### PR TITLE
Switch to Redisson for Redis configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.github.project-coco"
-version = "1.0.46-RELEASE"
+version = "1.0.47-RELEASE"
 
 repositories {
     mavenCentral()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,7 +93,8 @@ r2dbc-pool = { module = "io.r2dbc:r2dbc-pool", version.ref = "r2dbc" }
 
 redis = { module = "org.springframework.boot:spring-boot-starter-data-redis", version = "3.2.4" }
 redis-lettuce = { module = "io.lettuce:lettuce-core", version = "6.5.1.RELEASE" }
-redis-redisson = { module = "org.redisson:redisson", version = "3.35.0" }
+redis-redisson = { module = "org.redisson:redisson", version = "3.44.0" }
+redis-redisson-spring-boot-starter = { module = "org.redisson:redisson-spring-boot-starter", version = "3.44.0" }
 
 jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
 jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }

--- a/infra/infra-redis/build.gradle.kts
+++ b/infra/infra-redis/build.gradle.kts
@@ -11,8 +11,7 @@ allOpen {
 dependencies {
     api(project(":domain"))
     api(project(":application"))
-    api(libs.spring.boot.data.redis) {
-        implementation(libs.redis.lettuce)
-    }
+    api(libs.spring.boot.data.redis)
     api(libs.redis.redisson)
+    api(libs.redis.redisson.spring.boot.starter)
 }

--- a/infra/infra-redis/src/main/kotlin/org/coco/infra/redis/RedisClientConfig.kt
+++ b/infra/infra-redis/src/main/kotlin/org/coco/infra/redis/RedisClientConfig.kt
@@ -3,20 +3,22 @@ package org.coco.infra.redis
 import org.redisson.Redisson
 import org.redisson.api.RedissonClient
 import org.redisson.config.Config
+import org.redisson.spring.data.connection.RedissonConnectionFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.env.Environment
 
 @Configuration
-class RedisClientConfig(
-    env: Environment,
-) {
-    val redisHost = env.getProperty("app.redis.host") ?: "localhost"
-    val redisPort = (env.getProperty("app.redis.port") ?: "6379").toInt()
-    val redisPassword: String? = env.getProperty("app.redis.password")
-
+class RedisClientConfig {
     @Bean
-    fun redissonClient(): RedissonClient {
+    fun redissonConnectionFactory(redisson: RedissonClient): RedissonConnectionFactory = RedissonConnectionFactory(redisson)
+
+    @Bean(destroyMethod = "shutdown")
+    fun redisson(env: Environment): RedissonClient {
+        val redisHost = env.getRequiredProperty("spring.data.redis.host")
+        val redisPort = env.getRequiredProperty("spring.data.redis.port", Int::class.java)
+        val redisPassword: String? = env.getProperty("spring.data.redis.password")
+
         val config = Config()
         config
             .useSingleServer()

--- a/sample-project/src/main/resources/application-infra.yml
+++ b/sample-project/src/main/resources/application-infra.yml
@@ -1,7 +1,12 @@
 spring:
-  data.mongodb:
-    uri: ${MONGODB_URI}
-    database: ${MONGODB_DATABASE}
+  data:
+    mongodb:
+      uri: ${MONGODB_URI}
+      database: ${MONGODB_DATABASE}
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD}
   datasource:
     url: ${DATASOURCE_URL}
     username: ${DATASOURCE_USERNAME}
@@ -11,3 +16,10 @@ spring:
     hibernate:
       ddl-auto: create-drop
     open-in-view: false
+app:
+  auth:
+    issuer: ${ACCESS_TOKEN_ISSUER:project-coco}
+    access-token-secret: ${ACCESS_TOKEN_SECRET:access-token-secret}
+    refresh-token-secret: ${REFRESH_TOKEN_SECRET:refresh-token-secret}
+    access-token-expiration: 2h
+    refresh-token-expiration: 14d


### PR DESCRIPTION
### Description
- Replaced Lettuce with Redisson for Redis integration.
- Added Redisson Spring Boot Starter for improved Redis management.
- Updated `RedisClientConfig` to use `RedissonConnectionFactory`.
- Refined environment property naming conventions related to Redis.
- Enhanced sample project configuration to include Redis settings and application authentication parameters.